### PR TITLE
Fix with_setup_state bug on Python 3.4

### DIFF
--- a/metawrap/metawrap.py
+++ b/metawrap/metawrap.py
@@ -494,7 +494,7 @@ def with_setup_state(setup=None, teardown=None):
             ("teardown", teardown)
         ])
         stage_orderer = [(lambda a, b: (a, b)), (lambda a, b: (b, a))]
-        stage_itr = zip(reversed(stage_dict.items()), stage_orderer)
+        stage_itr = zip(reversed(list(stage_dict.items())), stage_orderer)
 
         for (each_stage_name, each_new_stage), each_stage_orderer in stage_itr:
             each_old_stage = getattr(a_callable, each_stage_name, None)


### PR DESCRIPTION
Convert `odict_items` to a `list` for `reversed` for Python 3.4 (and other Python version as well).

Python 3.5 added support for `OrderedDict`'s `items`, `keys`, and `values` iterator objects to be reversed by implemented `__reversed__`. Also Python 2.7 got both of all these as `list`s, which already had support for `__reversed__`. However, Python 3.4 had iterator objects returned by all of these methods that did not support `__reversed__`. Hence there were some test failures on Python 3.4 and `with_setup_state` failed. Here we fix this by always converting the result to a `list` regardless, which fixes the problem. More details on all of this in the references below.

xref: https://bugs.python.org/issue19505
xref: https://docs.python.org/3/whatsnew/3.5.html#collections
