### PR TITLE
Full test coverage

### DIFF
--- a/tests/test_metawrap.py
+++ b/tests/test_metawrap.py
@@ -110,6 +110,7 @@ class TestWrappers(unittest.TestCase):
         self.assertFalse(hasattr(func, "__wrapped__"))
         self.assertTrue(hasattr(func_wrapped, "__wrapped__"))
         self.assertEqual(func_wrapped.__wrapped__, func)
+        self.assertEqual(func_wrapped(0), func(0))
 
 
     def test_static_variables(self):


### PR DESCRIPTION
Seems that with `identity_wrapper` we were not exercising the wrapped function. This tries running the wrapped function and comparing its result to the unwrapped version to make sure they behave the same.